### PR TITLE
Content vocab impl

### DIFF
--- a/lib/MUD.tsx
+++ b/lib/MUD.tsx
@@ -3,6 +3,7 @@
 // LIT naming convention: "Class" (uppercase), "property" (lowercase)
 
 const MUD_BASE_URL = "https://raw.githubusercontent.com/Multi-User-Domain/vocab/main/mud.ttl";
+const MUD_CONTENT_BASE_URL = "https://raw.githubusercontent.com/Multi-User-Domain/vocab/main/mudcontent.ttl";
 
 export const MUD = {
     account: MUD_BASE_URL + '#Account',
@@ -17,6 +18,11 @@ export const MUD = {
 
     primaryTextContent: MUD_BASE_URL + '#primaryTextContent',
     primaryImageContent: MUD_BASE_URL + '#primaryImageContent',
+}
+
+export const MUD_CONTENT = {
+    content: MUD_CONTENT_BASE_URL + "#content",
+    sight: MUD_CONTENT_BASE_URL + "#sight",
 }
 
 // TODO: https://github.com/calummackervoy/mud-react/issues/4

--- a/lib/MUD.tsx
+++ b/lib/MUD.tsx
@@ -1,19 +1,22 @@
 
 
 // LIT naming convention: "Class" (uppercase), "property" (lowercase)
+
+const MUD_BASE_URL = "https://raw.githubusercontent.com/Multi-User-Domain/vocab/main/mud.ttl";
+
 export const MUD = {
-    account: 'https://calum.inrupt.net/public/voc/mud.ttl#Account',
-    charactersList: 'https://calum.inrupt.net/public/voc/mud.ttl#CharacterList',
+    account: MUD_BASE_URL + '#Account',
+    charactersList: MUD_BASE_URL + '#CharacterList',
     
-    Character: 'https://calum.inrupt.net/public/voc/mud.ttl#Character',
-    owner: 'https://calum.inrupt.net/public/voc/mud.ttl#ownedBy',
+    Character: MUD_BASE_URL + '#Character',
+    owner: MUD_BASE_URL + '#ownedBy',
 
-    Settlement: 'https://calum.inrupt.net/public/voc/mud.ttl#Settlement',
-    population: 'https://calum.inrupt.net/public/voc/mud.ttl#population',
-    hasBuilding: 'https://calum.inrupt.net/public/voc/mud.ttl#hasBuilding',
+    Settlement: MUD_BASE_URL + '#Settlement',
+    population: MUD_BASE_URL + '#population',
+    hasBuilding: MUD_BASE_URL + '#hasBuilding',
 
-    primaryTextContent: 'https://calum.inrupt.net/public/voc/mud.ttl#primaryTextContent',
-    primaryImageContent: 'https://calum.inrupt.net/public/voc/mud.ttl#primaryImageContent',
+    primaryTextContent: MUD_BASE_URL + '#primaryTextContent',
+    primaryImageContent: MUD_BASE_URL + '#primaryImageContent',
 }
 
 // TODO: https://github.com/calummackervoy/mud-react/issues/4

--- a/lib/MUD.tsx
+++ b/lib/MUD.tsx
@@ -1,7 +1,3 @@
-
-
-const MUD_BASE_URL = 'https://raw.githubusercontent.com/Multi-User-Domain/vocab/main/mud.ttl';
-
 // LIT naming convention: "Class" (uppercase), "property" (lowercase)
 
 const MUD_BASE_URL = "https://raw.githubusercontent.com/Multi-User-Domain/vocab/main/mud.ttl";

--- a/lib/PerceptionManager.tsx
+++ b/lib/PerceptionManager.tsx
@@ -1,0 +1,83 @@
+import { 
+    Thing,
+    getStringNoLocale,
+    getUrl, 
+    asUrl,
+    ThingPersisted
+} from '@inrupt/solid-client';
+
+import { VCARD } from "@inrupt/lit-generated-vocab-common";
+import { MUD, MUDAPI } from "./MUD";
+import { getContentRequest } from "./utils";
+
+/**
+ * Perception Manager is responsible for choosing what to display to the user, i.e. for deciding when it has enough content and what
+ * content should be displayed to the user, separated from the TerminalContext which is responsible for managing the feed and the
+ * Terminal component which is responsible for rendering it
+ * 
+ * PM: what and why
+ * Context: where
+ * Component: how
+ * 
+ * TODO: when? Maybe a message scehduler, informed by user settings and the PM?
+ */
+
+export interface ITerminalMessage {
+    id: string;
+    read?: boolean;
+    content: string | React.ReactElement;
+}
+
+export interface IPerceptionManager {
+    getITerminalMessage: (content: string | React.ReactElement) => ITerminalMessage;
+    describeThing: (worldWebId: string, thing: Thing) => Promise<ITerminalMessage[]>;
+};
+
+export const perceptionManager: IPerceptionManager = (() => {
+    let recentUris = [];
+
+    const getITerminalMessage = (content: string | React.ReactElement) : ITerminalMessage => {
+        return {
+            id: Math.random().toString(36).substr(2, 9),
+            read: false,
+            content: content
+        };
+    }
+
+    /**
+     * method describes parameterised Thing by adding relevant messages to the feed
+     * @param thing: Thing to describe
+     */
+    const describeThing = (worldWebId, thing: Thing) : Promise<ITerminalMessage[]> => {
+        // add a fast message with the name and description (and possibly image)
+        const uri = asUrl(thing as ThingPersisted);
+        const imageUrl = getUrl(thing, MUD.primaryImageContent);
+        let newMessages: ITerminalMessage[] = [];
+
+        if(imageUrl && !recentUris.includes(uri)) {
+            newMessages.push(getITerminalMessage(<img src={imageUrl}></img>));
+        }
+
+        const msg = (getStringNoLocale(thing, VCARD.fn) + ". " || "") + (getStringNoLocale(thing, MUD.primaryTextContent) || "");
+        if(msg.length > 3) {
+            newMessages.push(getITerminalMessage(msg));
+        }
+
+        // search for content online
+        return getContentRequest(worldWebId + MUDAPI.contentPath, uri).then((response) => {
+            if(response && response.data != null) {
+                newMessages.push(getITerminalMessage(response.data));
+            }
+
+            // remember previous descriptions and don't repeat
+            recentUris.push(uri);
+
+            return newMessages;
+        });
+    }
+
+    return {
+        getITerminalMessage: getITerminalMessage,
+        describeThing: describeThing
+    };
+})();

--- a/lib/context/terminalFeedContext/index.tsx
+++ b/lib/context/terminalFeedContext/index.tsx
@@ -39,8 +39,8 @@ export const TerminalFeedProvider = ({
         setMessages(messages.concat(message));
     }
 
-    const addMessages = (messages: ITerminalMessage[]) : void => {
-        setMessages(messages.concat(messages));
+    const addMessages = (retMessages: ITerminalMessage[]) : void => {
+        setMessages(messages.concat(retMessages));
     }
 
     /**

--- a/lib/context/terminalFeedContext/index.tsx
+++ b/lib/context/terminalFeedContext/index.tsx
@@ -11,7 +11,7 @@ import {
 
 import useMudWorld from "../../hooks/useMudWorld";
 
-import { ITerminalMessage, IPerceptionManager, perceptionManager } from "../../PerceptionManager";
+import { ITerminalMessage, IPerceptionManager } from "../../PerceptionManager";
 
 export interface ITerminalFeedContext {
     messages: ITerminalMessage[];
@@ -27,7 +27,8 @@ export interface ITerminalFeedProvider {
 export const TerminalFeedContext = createContext<ITerminalFeedContext>({messages: null});
 
 export const TerminalFeedProvider = ({
-    children
+    children,
+    perceptionManager
 }: ITerminalFeedProvider): ReactElement => {
     const { worldWebId } = useMudWorld();
     const [ messages, setMessages ] = useState<ITerminalMessage[]>([]);

--- a/lib/context/terminalFeedContext/index.tsx
+++ b/lib/context/terminalFeedContext/index.tsx
@@ -1,27 +1,17 @@
 import { 
-    Thing,
-    getStringNoLocale,
-    getUrl, 
-    asUrl,
-    ThingPersisted
+    Thing
 } from '@inrupt/solid-client';
 import {
+    ReactNode,
     ReactElement,
     createContext,
     useState,
     useEffect
 } from 'react';
-import { VCARD } from "@inrupt/lit-generated-vocab-common";
-import { MUD, MUDAPI } from "../../MUD";
 
-import { getContentRequest } from "../../utils";
 import useMudWorld from "../../hooks/useMudWorld";
 
-export interface ITerminalMessage {
-    id: string;
-    read?: boolean;
-    content: string | React.ReactElement;
-}
+import { ITerminalMessage, IPerceptionManager, perceptionManager } from "../../PerceptionManager";
 
 export interface ITerminalFeedContext {
     messages: ITerminalMessage[];
@@ -29,61 +19,37 @@ export interface ITerminalFeedContext {
     describeThing?: (Thing) => void;
 }
 
+export interface ITerminalFeedProvider {
+    children: ReactNode;
+    perceptionManager: IPerceptionManager;
+};
+
 export const TerminalFeedContext = createContext<ITerminalFeedContext>({messages: null});
 
 export const TerminalFeedProvider = ({
     children
-}): ReactElement => {
-    const [ messages, setMessages ] = useState<ITerminalMessage[]>([]);
+}: ITerminalFeedProvider): ReactElement => {
     const { worldWebId } = useMudWorld();
-    const [ recentUris, setRecentUris] = useState([]);
-
-    const getITerminalMessage = (content: string | React.ReactElement) : ITerminalMessage => {
-        return {
-            id: Math.random().toString(36).substr(2, 9),
-            read: false,
-            content: content
-        };
-    }
+    const [ messages, setMessages ] = useState<ITerminalMessage[]>([]);
 
     // a method for adding a string directly
     const addMessage = (content: string | React.ReactElement) : void => {
-        let message: ITerminalMessage = getITerminalMessage(content);
+        let message: ITerminalMessage = perceptionManager.getITerminalMessage(content);
         setMessages(messages.concat(message));
+    }
+
+    const addMessages = (messages: ITerminalMessage[]) : void => {
+        setMessages(messages.concat(messages));
     }
 
     /**
      * method describes parameterised Thing by adding relevant messages to the feed
      * @param thing: Thing to describe
-     * TODO: manage multiple content servers and try each as a fallback
-     * TODO: possibly make own content enrichment if possible
      */
-    
     const describeThing = (thing: Thing) : void => {
-        // add a fast message with the name and description (and possibly image)
-        const uri = asUrl(thing as ThingPersisted);
-        const imageUrl = getUrl(thing, MUD.primaryImageContent);
-        let newMessages: ITerminalMessage[] = [];
-
-        if(imageUrl && !recentUris.includes(uri)) {
-            newMessages.push(getITerminalMessage(<img src={imageUrl}></img>));
-        }
-
-        const msg = (getStringNoLocale(thing, VCARD.fn) + ". " || "") + (getStringNoLocale(thing, MUD.primaryTextContent) || "");
-        if(msg.length > 3) {
-            newMessages.push(getITerminalMessage(msg));
-        }
-
-        // search for content online
-        getContentRequest(worldWebId + MUDAPI.contentPath, uri).then((response) => {
-            if(response && response.data != null) {
-                newMessages.push(getITerminalMessage(response.data));
-            }
-            setMessages(messages.concat(newMessages));
+        perceptionManager.describeThing(worldWebId, thing).then((messages) => {
+            addMessages(messages);
         });
-
-        // remember previous descriptions and don't repeat
-        setRecentUris(recentUris.concat(uri));
     }
 
     useEffect(() => {

--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -1,7 +1,12 @@
+import { Quad } from "rdf-js";
+
 import {
+    createSolidDataset,
+    getSolidDataset,
     getThingAll,
-    getUrl
-  } from "@inrupt/solid-client";
+    getUrl,
+    SolidDataset
+} from "@inrupt/solid-client";
 
 import {RDF} from "@inrupt/lit-generated-vocab-common";
 
@@ -19,10 +24,71 @@ export const getFilteredThings = (dataset, propertyType) => {
     return ret
 };
 
+export async function turtleToTriples(
+    raw: string
+  ): Promise<Quad[]> {
+    const format = "text/turtle";
+    const n3 = await loadN3();
+    const parser = new n3.Parser({ format: format });
+  
+    const parsingPromise = new Promise<Quad[]>((resolve, reject) => {
+      const parsedTriples: Quad[] = [];
+      parser.parse(raw, (error, triple, _prefixes) => {
+        if (error) {
+          return reject(error);
+        }
+        if (triple) {
+          parsedTriples.push(triple);
+        } else {
+          resolve(parsedTriples);
+        }
+      });
+    });
+  
+    return parsingPromise;
+  }
+  
+  async function loadN3() {
+    // When loaded via Webpack or another bundler that looks at the `modules` field in package.json,
+    // N3 serves up ES modules with named exports.
+    // However, when it is loaded in Node, it serves up a CommonJS module, which, when imported from
+    // a Node ES module, is in the shape of a default export that is an object with all the named
+    // exports as its properties.
+    // This means that if we were to import the default module, our code would fail in Webpack,
+    // whereas if we imported the named exports, our code would fail in Node.
+    // As a workaround, we use a dynamic import. This way, we can use the same syntax in every
+    // environment, where the differences between the environments are in whether the returned object
+    // includes a `default` property that contains all exported functions, or whether those functions
+    // are available on the returned object directly. We can then respond to those different
+    // situations at runtime.
+    // Unfortunately, that does mean that tree shaking will not work until N3 also provides ES modules
+    // for Node, or adds a default export for Webpack. See
+    // https://github.com/rdfjs/N3.js/issues/196
+    const n3Module = await import("n3");
+    /* istanbul ignore if: the package provides named exports in the unit test environment */
+    if (typeof n3Module.default !== "undefined") {
+      return n3Module.default;
+    }
+    return n3Module;
+  }
+
+export const parseTurtleToSolidDataset = async (turtle: string) : Promise<SolidDataset> => {
+    const triples = await turtleToTriples(turtle);
+    const resource = createSolidDataset();
+    triples.forEach((triple) => resource.add(triple));
+
+    return resource;
+}
+
 /**
  * @param uri: the URI of the Thing which I want to describe 
  * @returns content returned from the server (should be a plain text string). Null if the server had no content
 */
 export const getContentRequest = async (contentServerURL: string, uri: string) : Promise<any> => {
+    /*let url = new URL(contentServerURL)
+    let params = [['uri', uri]]
+    url.search = new URLSearchParams(params).toString();*/
+
+    //return getSolidDataset(contentServerURL, );
     return await axios.get(contentServerURL, { params: { uri: uri } });
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,6 +11,7 @@ import {
   LogoutButton,
 } from "@inrupt/solid-ui-react";
 
+import { perceptionManager } from "../lib/PerceptionManager";
 import { MudWorldProvider } from "../lib/context/mudWorldContext";
 import { MudAccountProvider } from "../lib/context/mudAccountContext";
 import { TerminalFeedProvider } from "../lib/context/terminalFeedContext";
@@ -47,7 +48,7 @@ export default function Home(): React.ReactElement {
     //TODO: select the worldWebId from a WorldFinder component
     <MudWorldProvider worldWebId="http://localhost:8080/">
       <MudAccountProvider webId={webId}>
-        <TerminalFeedProvider>
+        <TerminalFeedProvider perceptionManager={perceptionManager}>
           {header}
           <Container style={{marginBottom: "20px"}}>
             <GameWindow />


### PR DESCRIPTION
Front-end implementation for https://github.com/Multi-User-Domain/mud-jena/pull/7

Adds `PerceptionManager` class which for now just parses turtle content from the response based on the new vocab

Leverages new utility function which hacks around current SolidDataset limitations, namely that you can't give `getSolidDataset` query parameters and you can't use the API to parse a turtle file into one (without performing the fetch through the API as well). Planning on opening an issue with them about it soon